### PR TITLE
Update _generic_decisions.txt

### DIFF
--- a/Cold War Iron Curtain/common/decisions/_generic_decisions.txt
+++ b/Cold War Iron Curtain/common/decisions/_generic_decisions.txt
@@ -1433,11 +1433,14 @@ operations = {
 					613 = { is_fully_controlled_by = PRC  } 
 				}
 				news_event = Shanghai_Campaign.1
-				set_country_flag = roc_rebound_shanghai
+				set_country_flag = roc_lost_shanghai
 			}
 			else = {
 				news_event = Shanghai_Campaign.2 
 				set_country_flag = roc_rebound_shanghai
+				PRC = {
+					set_country_flag = roc_rebound_shanghai
+				}
 			}
 		}
 
@@ -1676,6 +1679,7 @@ operations = {
 					CHI = {
 						remove_ideas = Inflation_Crisis 
 						remove_ideas = CHI_disorganized_military
+						remove_ideas = CHI_disorganized_military2
 						add_ideas = rural_poverty_crisis_2
 						add_ideas = fractured_legal_system_2
 						add_ideas = hyperinflation1
@@ -1699,7 +1703,7 @@ operations = {
 						transfer_state = 607
 						transfer_state = 615
 						transfer_state = 622		
-						set_capital = 613
+						set_capital = 598
 					}
 					SIK = {
 						complete_national_focus = ETR_Ehmetjan_Qasimi_Consolidates_Power


### PR DESCRIPTION
add remove_ideas = CHI_disorganized_military2 to fix problems if you hold shanghai and get a weakened debuff but this debuff can't be removed
Reset the KMT China's Capital to Nanking, since it is more historically as their Capital
Change the The_Shanghai_Campaign mission of set_country_flag, now if Shanghai is guarded by CHI, PRC will also get the country_flag of roc_rebound_shanghai to fix the peace deal bug; and if CHI lost Shanghai, they get roc_lost_shanghai country_flag to push the main branch of ROC_50s Tree before lost all of mainland